### PR TITLE
Added support for Spring Boot 3.0

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -3,10 +3,12 @@
 
 this is a simple abstraction / utility layer on top of mongo db.  from version 0.9, these are the minimum requirements:
 
-- Spring Boot 2.5
-- Java Mongo 4.2
+- Spring Framework 5.3 (Spring Boot 2.5)
+- MongoDB Driver 4.2
 - Mongojack 4.2
 - MongoDB 4.4
+
+from version 0.10 added compatibility for Spring Framework 6.0 (Spring Boot 3.0).
 
 it contains a few basic classes that might help, specifically:
 
@@ -20,7 +22,7 @@ this is an interface for a builder style class to create queries. a basic implem
 	[...]
 
 
-​	
+​
 ***DataStore***
 
 an interface for a data store that can be queried with a DbQuery. an implementation for mongo (along with the necessary translator to translate DbQuery into an actual mongo query is provided in dbstore-mongo and dbstore-query-mongo). simple usage:
@@ -33,11 +35,11 @@ an interface for a data store that can be queried with a DbQuery. an implementat
 	DataStore ds = getDataStore();
 	return ds.findObjects(MyClass.class,q);
 
-and, for saving: 
+and, for saving:
 
 	ds.saveObject("my_db",object);
 
-note that your objects have to extend `DBStoreEntity`. 
+note that your objects have to extend `DBStoreEntity`.
 
 
 ***DbStoreListener***

--- a/dbstore-api/pom.xml
+++ b/dbstore-api/pom.xml
@@ -7,14 +7,20 @@
     <parent>
         <groupId>com.cinefms.dbstore</groupId>
         <artifactId>dbstore</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.cinefms.dbstore</groupId>
             <artifactId>dbstore-query-api</artifactId>
-            <version>0.9.4-SNAPSHOT</version>
+            <version>0.10.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mongojack</groupId>
+            <artifactId>mongojack</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/dbstore-api/src/main/java/com/cinefms/dbstore/api/DBStoreEntity.java
+++ b/dbstore-api/src/main/java/com/cinefms/dbstore/api/DBStoreEntity.java
@@ -1,7 +1,6 @@
 package com.cinefms.dbstore.api;
 
-import javax.persistence.Id;
-
+import org.mongojack.Id;
 
 public interface DBStoreEntity {
 

--- a/dbstore-mongo/pom.xml
+++ b/dbstore-mongo/pom.xml
@@ -7,19 +7,19 @@
     <parent>
         <groupId>com.cinefms.dbstore</groupId>
         <artifactId>dbstore</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.cinefms.dbstore</groupId>
             <artifactId>dbstore-api</artifactId>
-            <version>0.9.4-SNAPSHOT</version>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.cinefms.dbstore</groupId>
             <artifactId>dbstore-query-mongo</artifactId>
-            <version>0.9.4-SNAPSHOT</version>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -28,8 +28,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
         </dependency>
 
         <dependency>

--- a/dbstore-query-api/pom.xml
+++ b/dbstore-query-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.cinefms.dbstore</groupId>
         <artifactId>dbstore</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dbstore-query-api</artifactId>

--- a/dbstore-query-mongo/pom.xml
+++ b/dbstore-query-mongo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.cinefms.dbstore</groupId>
         <artifactId>dbstore</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dbstore-query-mongo</artifactId>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.cinefms.dbstore</groupId>
             <artifactId>dbstore-query-api</artifactId>
-            <version>0.9.4-SNAPSHOT</version>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/dbstore-redis/pom.xml
+++ b/dbstore-redis/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.cinefms.dbstore</groupId>
         <artifactId>dbstore</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.2</version>
+        <version>3.0.1</version>
     </parent>
 
     <groupId>com.cinefms.dbstore</groupId>
     <artifactId>dbstore</artifactId>
-    <version>0.9.4-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -22,11 +22,12 @@
     </modules>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>8</java.version>
+        <maven.compiler.release>8</maven.compiler.release>
 
-        <mongojack.version>4.2.0</mongojack.version>
+        <mongojack.version>4.8.0</mongojack.version>
         <redisson.version>1.3.1</redisson.version>
-        <testcontainers.version>1.16.0</testcontainers.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
     </properties>
 
     <licenses>
@@ -80,12 +81,6 @@
                 <groupId>org.mongojack</groupId>
                 <artifactId>mongojack</artifactId>
                 <version>${mongojack.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.persistence</groupId>
-                        <artifactId>persistence-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -104,12 +99,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
Upgraded to MongoJack 4.8 which supports mongodb driver up to version 4.8 (which comes bundled with Spring Framework 6, i.e. Spring Boot 3).

Since Spring Framework 5 and 6 uses different Persistence API (Spring 5 javax, Spring 6 jakarta) I decided to replace `DBStoreEntity` id annotation with `org.mongojack.Id` which comes bundled with MongoJack and behaves exactly the same as the one from Persistence API.

Since all project dependencies were updated to newer versions JVM 17 is now baseline for building the project but interoperability with JAVA 8 was preserved by setting cross compilation to JAVA 8 bytecode. This means that library may still be used on older JVM with Spring Framework 5.x and Spring Boot 2.x.